### PR TITLE
feat: add watchlist command and --type filter for history

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -441,6 +441,55 @@ type SearchResult struct {
 	} `json:"show,omitempty"`
 }
 
+type SyncHistoryReq struct {
+	Movies []SyncItem `json:"movies,omitempty"`
+	Shows  []SyncItem `json:"shows,omitempty"`
+}
+
+type SyncItem struct {
+	WatchedAt string `json:"watched_at,omitempty"`
+	Ids       struct {
+		Trakt int `json:"trakt"`
+	} `json:"ids"`
+}
+
+type SyncHistoryResp struct {
+	Added struct {
+		Movies   int `json:"movies"`
+		Episodes int `json:"episodes"`
+	} `json:"added"`
+	NotFound struct {
+		Movies []interface{} `json:"movies"`
+		Shows  []interface{} `json:"shows"`
+	} `json:"not_found"`
+}
+
+func (c *APIClient) SyncHistory(req *SyncHistoryReq) (*SyncHistoryResp, error) {
+	httpResp, err := c.doRequest(requestParams{
+		method: http.MethodPost,
+		path:   "/sync/history",
+		body:   req,
+		auth:   true,
+	})
+	if err != nil {
+		return nil, err
+	}
+	defer httpResp.Body.Close()
+
+	if httpResp.StatusCode != 201 {
+		body, _ := ioutil.ReadAll(httpResp.Body)
+		return nil, fmt.Errorf("sync history failed (%s): %s", httpResp.Status, string(body))
+	}
+
+	var resp SyncHistoryResp
+	err = json.NewDecoder(httpResp.Body).Decode(&resp)
+	if err != nil {
+		return nil, err
+	}
+
+	return &resp, nil
+}
+
 func (c *APIClient) Search(query string, searchType string) ([]SearchResult, error) {
 	httpResp, err := c.doRequest(requestParams{
 		method: http.MethodGet,

--- a/api/api.go
+++ b/api/api.go
@@ -239,10 +239,15 @@ type Pagination struct {
 	ItemCount string `json:"item_count"`
 }
 
-func (c *APIClient) GetUserHistory(user string, params PaginationsParams) (UserHistory, Pagination, error) {
+func (c *APIClient) GetUserHistory(user string, historyType string, params PaginationsParams) (UserHistory, Pagination, error) {
+	path := fmt.Sprintf("/users/%s/history", user)
+	if historyType != "" {
+		path += "/" + historyType
+	}
+
 	httpResp, err := c.doRequest(requestParams{
 		method:     http.MethodGet,
-		path:       fmt.Sprintf("/users/%s/history", user),
+		path:       path,
 		body:       nil,
 		auth:       true,
 		pagination: params,
@@ -341,6 +346,73 @@ func (c *APIClient) GetUserSettings() (UserSettings, error) {
 	}
 
 	return resp, nil
+}
+
+type WatchlistItem struct {
+	Rank    int       `json:"rank"`
+	ID      int64     `json:"id"`
+	ListedAt time.Time `json:"listed_at"`
+	Notes   string    `json:"notes"`
+	Type    string    `json:"type"`
+	Movie   *struct {
+		Title string `json:"title"`
+		Year  int    `json:"year"`
+		Ids   struct {
+			Trakt int    `json:"trakt"`
+			Slug  string `json:"slug"`
+			Imdb  string `json:"imdb"`
+			Tmdb  int    `json:"tmdb"`
+		} `json:"ids"`
+	} `json:"movie,omitempty"`
+	Show *struct {
+		Title string `json:"title"`
+		Year  int    `json:"year"`
+		Ids   struct {
+			Trakt int    `json:"trakt"`
+			Slug  string `json:"slug"`
+			Tvdb  int    `json:"tvdb"`
+			Imdb  string `json:"imdb"`
+			Tmdb  int    `json:"tmdb"`
+		} `json:"ids"`
+	} `json:"show,omitempty"`
+}
+
+func (c *APIClient) GetUserWatchlist(user string, listType string, params PaginationsParams) ([]WatchlistItem, Pagination, error) {
+	path := fmt.Sprintf("/users/%s/watchlist", user)
+	if listType != "" {
+		path += "/" + listType
+	}
+
+	httpResp, err := c.doRequest(requestParams{
+		method:     http.MethodGet,
+		path:       path,
+		body:       nil,
+		auth:       true,
+		pagination: params,
+	})
+	if err != nil {
+		return nil, Pagination{}, err
+	}
+	defer httpResp.Body.Close()
+
+	if httpResp.StatusCode != 200 {
+		return nil, Pagination{}, fmt.Errorf("failed to get watchlist: %s", httpResp.Status)
+	}
+
+	var resp []WatchlistItem
+	err = json.NewDecoder(httpResp.Body).Decode(&resp)
+	if err != nil {
+		return nil, Pagination{}, err
+	}
+
+	pagination := Pagination{
+		Page:      httpResp.Header.Get("X-Pagination-Page"),
+		Limit:     httpResp.Header.Get("X-Pagination-Limit"),
+		PageCount: httpResp.Header.Get("X-Pagination-Page-Count"),
+		ItemCount: httpResp.Header.Get("X-Pagination-Item-Count"),
+	}
+
+	return resp, pagination, nil
 }
 
 type SearchResult struct {

--- a/cmd/history.go
+++ b/cmd/history.go
@@ -39,8 +39,12 @@ var historyCmd = &cobra.Command{
 		if err != nil {
 			logrus.WithError(err).Fatal("Failed to get limit")
 		}
+		historyType, err := cmd.Flags().GetString("type")
+		if err != nil {
+			logrus.WithError(err).Fatal("Failed to get type")
+		}
 
-		resp, pagination, err := client.GetUserHistory(settings.User.Ids.Slug, api.PaginationsParams{
+		resp, pagination, err := client.GetUserHistory(settings.User.Ids.Slug, historyType, api.PaginationsParams{
 			Page:  page,
 			Limit: limit,
 		})
@@ -91,6 +95,7 @@ func init() {
 
 	historyCmd.Flags().Int("page", 1, "")
 	historyCmd.Flags().Int("limit", 10, "")
+	historyCmd.Flags().String("type", "", "Filter by type (movies, shows)")
 
 	// Here you will define your flags and configuration settings.
 

--- a/cmd/history_add.go
+++ b/cmd/history_add.go
@@ -1,0 +1,154 @@
+package cmd
+
+import (
+	"fmt"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/angristan/trakt-cli/api"
+	"github.com/briandowns/spinner"
+	"github.com/jedib0t/go-pretty/v6/table"
+	"github.com/muesli/termenv"
+	"github.com/sirupsen/logrus"
+	"github.com/spf13/cobra"
+)
+
+var historyAddCmd = &cobra.Command{
+	Use:   "add [show or movie names...]",
+	Short: "Add items to your watch history",
+	Long:  `Search for shows or movies by name and add them to your watch history.`,
+	Args:  cobra.MinimumNArgs(1),
+	Run: func(cmd *cobra.Command, args []string) {
+		client := api.NewAPIClient()
+		itemType, _ := cmd.Flags().GetString("type")
+		watchedAt, _ := cmd.Flags().GetString("watched-at")
+
+		if itemType == "" {
+			itemType = "show"
+		}
+
+		// Validate watched-at if provided
+		if watchedAt != "" {
+			if _, err := time.Parse(time.RFC3339, watchedAt); err != nil {
+				// Try date-only format and convert to RFC3339
+				if t, err2 := time.Parse("2006-01-02", watchedAt); err2 == nil {
+					watchedAt = t.UTC().Format(time.RFC3339)
+				} else {
+					logrus.Fatalf("Invalid --watched-at format. Use RFC3339 (2023-01-15T00:00:00Z) or date (2023-01-15)")
+				}
+			}
+		}
+
+		searchType := itemType
+		if searchType == "movie" {
+			searchType = "movie"
+		} else {
+			searchType = "show"
+		}
+
+		s := spinner.New(spinner.CharSets[2], 100*time.Millisecond)
+
+		syncReq := &api.SyncHistoryReq{}
+
+		t := table.NewWriter()
+		t.SetOutputMirror(os.Stdout)
+		t.AppendHeader(table.Row{
+			termenv.String("Query").Bold(),
+			termenv.String("Matched").Bold(),
+			termenv.String("Year").Bold(),
+			termenv.String("Trakt ID").Bold(),
+		})
+
+		for _, query := range args {
+			s.Prefix = fmt.Sprintf("Searching for \"%s\"... ", query)
+			s.Start()
+
+			results, err := client.Search(query, searchType)
+			s.Stop()
+			if err != nil {
+				logrus.WithError(err).Errorf("Failed to search for %s", query)
+				continue
+			}
+
+			if len(results) == 0 {
+				p := termenv.ColorProfile()
+				t.AppendRow([]interface{}{
+					query,
+					termenv.String("NOT FOUND").Foreground(p.Color("#FF6B6B")),
+					"",
+					"",
+				})
+				continue
+			}
+
+			// Prefer exact title match over first result
+			result := results[0]
+			queryLower := strings.ToLower(strings.TrimSpace(query))
+			for _, r := range results {
+				var title string
+				if searchType == "movie" && r.Movie != nil {
+					title = r.Movie.Title
+				} else if r.Show != nil {
+					title = r.Show.Title
+				}
+				if strings.ToLower(title) == queryLower {
+					result = r
+					break
+				}
+			}
+			item := api.SyncItem{}
+			item.WatchedAt = watchedAt
+
+			if searchType == "movie" && result.Movie != nil {
+				item.Ids.Trakt = result.Movie.Ids.Trakt
+				syncReq.Movies = append(syncReq.Movies, item)
+				t.AppendRow([]interface{}{
+					query,
+					result.Movie.Title,
+					result.Movie.Year,
+					result.Movie.Ids.Trakt,
+				})
+			} else if result.Show != nil {
+				item.Ids.Trakt = result.Show.Ids.Trakt
+				syncReq.Shows = append(syncReq.Shows, item)
+				t.AppendRow([]interface{}{
+					query,
+					result.Show.Title,
+					result.Show.Year,
+					result.Show.Ids.Trakt,
+				})
+			}
+		}
+
+		t.SetStyle(table.StyleRounded)
+		t.Render()
+
+		if len(syncReq.Shows) == 0 && len(syncReq.Movies) == 0 {
+			fmt.Println("\nNo items to add.")
+			return
+		}
+
+		fmt.Printf("\nAdding %d shows and %d movies to history...\n", len(syncReq.Shows), len(syncReq.Movies))
+
+		s.Prefix = "Syncing... "
+		s.Start()
+		resp, err := client.SyncHistory(syncReq)
+		s.Stop()
+		if err != nil {
+			logrus.WithError(err).Fatal("Failed to sync history")
+		}
+
+		fmt.Printf("Added: %d movies, %d episodes\n", resp.Added.Movies, resp.Added.Episodes)
+		if len(resp.NotFound.Movies) > 0 || len(resp.NotFound.Shows) > 0 {
+			fmt.Printf("Not found: %d movies, %d shows\n", len(resp.NotFound.Movies), len(resp.NotFound.Shows))
+		}
+	},
+}
+
+func init() {
+	historyCmd.AddCommand(historyAddCmd)
+
+	historyAddCmd.Flags().String("type", "show", "Type of item (show, movie)")
+	historyAddCmd.Flags().String("watched-at", "", "When the items were watched (RFC3339 or YYYY-MM-DD). Defaults to now")
+}

--- a/cmd/watchlist.go
+++ b/cmd/watchlist.go
@@ -1,0 +1,103 @@
+package cmd
+
+import (
+	"fmt"
+	"os"
+	"time"
+
+	"github.com/angristan/trakt-cli/api"
+	"github.com/briandowns/spinner"
+	"github.com/jedib0t/go-pretty/v6/table"
+	"github.com/mergestat/timediff"
+	"github.com/muesli/termenv"
+	"github.com/sirupsen/logrus"
+	"github.com/spf13/cobra"
+)
+
+var watchlistCmd = &cobra.Command{
+	Use:   "watchlist",
+	Short: "Show your watchlist",
+	Long:  `Show your watchlist of movies and TV shows you want to watch.`,
+	Run: func(cmd *cobra.Command, args []string) {
+		client := api.NewAPIClient()
+
+		s := spinner.New(spinner.CharSets[2], 100*time.Millisecond)
+		s.Start()
+		s.Prefix = "Loading watchlist... "
+
+		settings, err := client.GetUserSettings()
+		if err != nil {
+			logrus.WithError(err).Fatal("Failed to get user settings")
+		}
+
+		page, err := cmd.Flags().GetInt("page")
+		if err != nil {
+			logrus.WithError(err).Fatal("Failed to get page")
+		}
+		limit, err := cmd.Flags().GetInt("limit")
+		if err != nil {
+			logrus.WithError(err).Fatal("Failed to get limit")
+		}
+		listType, err := cmd.Flags().GetString("type")
+		if err != nil {
+			logrus.WithError(err).Fatal("Failed to get type")
+		}
+
+		resp, pagination, err := client.GetUserWatchlist(settings.User.Ids.Slug, listType, api.PaginationsParams{
+			Page:  page,
+			Limit: limit,
+		})
+		if err != nil {
+			fmt.Println(err)
+			return
+		}
+
+		t := table.NewWriter()
+		t.SetOutputMirror(os.Stdout)
+		t.AppendHeader(table.Row{
+			termenv.String("Type").Bold(),
+			termenv.String("Title").Bold(),
+			termenv.String("Added").Bold(),
+		})
+		for _, v := range resp {
+			switch v.Type {
+			case "movie":
+				if v.Movie != nil {
+					p := termenv.ColorProfile()
+					year := termenv.String(fmt.Sprintf("(%d)", v.Movie.Year)).Foreground(p.Color("#B9BFCA"))
+					t.AppendRow([]interface{}{
+						"Movie 🎬",
+						fmt.Sprintf("%s %s", v.Movie.Title, year),
+						timediff.TimeDiff(v.ListedAt),
+					})
+				}
+			case "show":
+				if v.Show != nil {
+					p := termenv.ColorProfile()
+					year := termenv.String(fmt.Sprintf("(%d)", v.Show.Year)).Foreground(p.Color("#B9BFCA"))
+					t.AppendRow([]interface{}{
+						"TV Show 📺",
+						fmt.Sprintf("%s %s", v.Show.Title, year),
+						timediff.TimeDiff(v.ListedAt),
+					})
+				}
+			}
+		}
+
+		t.SetStyle(table.StyleRounded)
+
+		s.Stop()
+
+		t.Render()
+
+		fmt.Printf("Page %s out of %s, %s items in total", pagination.Page, pagination.PageCount, pagination.ItemCount)
+	},
+}
+
+func init() {
+	rootCmd.AddCommand(watchlistCmd)
+
+	watchlistCmd.Flags().Int("page", 1, "")
+	watchlistCmd.Flags().Int("limit", 10, "")
+	watchlistCmd.Flags().String("type", "", "Filter by type (movies, shows)")
+}


### PR DESCRIPTION
## Summary

- Add `watchlist` command to view the user's watchlist (movies and shows they want to watch), with `--page`, `--limit`, and `--type` flags
- Add `--type movies|shows` filter to the existing `history` command, using the `/users/{slug}/history/{type}` API endpoint
- Add `history add` subcommand to mark shows/movies as watched via `POST /sync/history`
  - Searches by name with exact title matching to avoid false positives
  - Supports `--watched-at` flag (RFC3339 or YYYY-MM-DD) to backdate entries
  - Accepts multiple titles as arguments for batch operations
- All commands follow the existing code patterns (spinner, styled table output, pagination footer)

## Examples

```bash
# View watchlist
trakt-cli watchlist
trakt-cli watchlist --type movies --limit 20

# Filter history by type
trakt-cli history --type movies
trakt-cli history --type shows --limit 5

# Add shows to watch history
trakt-cli history add "The Sopranos" "The Wire" "Breaking Bad"
trakt-cli history add --type movie "The Godfather" "Pulp Fiction"
trakt-cli history add --watched-at 2020-06-15 "Dark"
```

## Test plan

- [x] `trakt-cli watchlist` returns paginated watchlist items
- [x] `trakt-cli watchlist --type movies` filters to movies only
- [x] `trakt-cli watchlist --type shows` filters to shows only
- [x] `trakt-cli history --type movies` returns only movie history
- [x] `trakt-cli history --type shows` returns only show history
- [x] `trakt-cli history` (no --type) still returns all history (backwards compatible)
- [x] `trakt-cli history add "The Sopranos"` finds correct show (not documentary) and syncs
- [x] `trakt-cli history add` with multiple args batch-syncs all items
- [x] `--watched-at` accepts both RFC3339 and YYYY-MM-DD formats
- [x] `--watched-at` omitted defaults to current time

🤖 Generated with [Claude Code](https://claude.com/claude-code)